### PR TITLE
replace PHPUnit with Pest for running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,4 +47,4 @@ jobs:
         run: php artisan key:generate
 
       - name: Tests
-        run: ./vendor/bin/phpunit
+        run: ./vendor/bin/pest


### PR DESCRIPTION
This pull request updates the testing framework used in the GitHub Actions workflow for the project. The change replaces the `phpunit` command with the `pest` command in the test execution step.