### PR TITLE
Wip

### DIFF
--- a/database/factories/ContributionFactory.php
+++ b/database/factories/ContributionFactory.php
@@ -21,7 +21,7 @@ class ContributionFactory extends Factory
             'amount' => $this->faker->randomFloat(2, 10, 100),
             'date' => $this->faker->dateTimeBetween('-1 year', 'now'),
             'recorded_by_id' => User::factory(),
-            'description' => $this->faker->optional(0.7)->sentence(),
+            'notes' => $this->faker->optional(0.7)->sentence(),
         ];
     }
 
@@ -35,13 +35,13 @@ class ContributionFactory extends Factory
         return $this->state(['date' => $date]);
     }
 
-    public function withDescription(string $description): self
+    public function withNotes(string $notes): self
     {
-        return $this->state(['description' => $description]);
+        return $this->state(['notes' => $notes]);
     }
 
-    public function withoutDescription(): self
+    public function withoutNotes(): self
     {
-        return $this->state(['description' => null]);
+        return $this->state(['notes' => null]);
     }
 }

--- a/tests/Feature/ContributionControllerTest.php
+++ b/tests/Feature/ContributionControllerTest.php
@@ -44,7 +44,7 @@ class ContributionControllerTest extends TestCase
             'name' => 'Married',
             'slug' => 'married',
             'monthly_fee' => 50.00,
-            'description' => 'Married members',
+            'notes' => 'Married members',
             'is_active' => true,
         ]);
 
@@ -114,7 +114,7 @@ class ContributionControllerTest extends TestCase
             'user_id' => $this->contributor->id,
             'amount' => 50.00,
             'date' => now()->format('Y-m-d'),
-            'description' => 'Monthly contribution',
+            'notes' => 'Monthly contribution',
         ];
 
         $response = $this->actingAs($this->financialSecretary)

--- a/tests/Feature/Feature/ContributionControllerTest.php
+++ b/tests/Feature/Feature/ContributionControllerTest.php
@@ -1,7 +1,0 @@
-<?php
-
-test('example', function () {
-    $response = $this->get('/');
-
-    $response->assertStatus(200);
-});

--- a/tests/Unit/Actions/CalculateUserBalanceActionTest.php
+++ b/tests/Unit/Actions/CalculateUserBalanceActionTest.php
@@ -28,7 +28,7 @@ class CalculateUserBalanceActionTest extends TestCase
             'name' => 'Test Category',
             'slug' => 'test',
             'monthly_fee' => 50.00,
-            'description' => 'Test category',
+            'notes' => 'Test category',
             'is_active' => true,
         ]);
 

--- a/tests/Unit/Actions/CreateContributionActionTest.php
+++ b/tests/Unit/Actions/CreateContributionActionTest.php
@@ -28,7 +28,7 @@ class CreateContributionActionTest extends TestCase
             'name' => 'Test Category',
             'slug' => 'test',
             'monthly_fee' => 25.00,
-            'description' => 'Test category',
+            'notes' => 'Test category',
             'is_active' => true,
         ]);
 
@@ -43,7 +43,7 @@ class CreateContributionActionTest extends TestCase
             'amount' => 50.00,
             'date' => '2024-01-15',
             'recorded_by_id' => $this->recorder->id,
-            'description' => 'Test contribution',
+            'notes' => 'Test contribution',
         ];
 
         $contribution = $this->action->execute($data);

--- a/tests/Unit/Actions/GetContributionSummaryActionTest.php
+++ b/tests/Unit/Actions/GetContributionSummaryActionTest.php
@@ -33,7 +33,7 @@ class GetContributionSummaryActionTest extends TestCase
             'name' => 'Married',
             'slug' => 'married',
             'monthly_fee' => 50.00,
-            'description' => 'Married members',
+            'notes' => 'Married members',
             'is_active' => true,
         ]);
 
@@ -41,7 +41,7 @@ class GetContributionSummaryActionTest extends TestCase
             'name' => 'Single',
             'slug' => 'single',
             'monthly_fee' => 30.00,
-            'description' => 'Single members',
+            'notes' => 'Single members',
             'is_active' => true,
         ]);
 


### PR DESCRIPTION
This pull request involves a refactor to rename the `description` field to `notes` across multiple files in the codebase. The changes ensure consistency in naming conventions and update related methods, tests, and factory definitions accordingly.

### Field Renaming in Factories:
* [`database/factories/ContributionFactory.php`](diffhunk://#diff-8fb802255fda50e4839bca0b2df5e414246c45fbf704fb52078c43a1e4d14e28L24-R24): Renamed `description` field to `notes` in the factory definition and updated related methods (`withDescription`, `withoutDescription`) to `withNotes` and `withoutNotes`. [[1]](diffhunk://#diff-8fb802255fda50e4839bca0b2df5e414246c45fbf704fb52078c43a1e4d14e28L24-R24) [[2]](diffhunk://#diff-8fb802255fda50e4839bca0b2df5e414246c45fbf704fb52078c43a1e4d14e28L38-R45)

### Field Renaming in Tests:
* [`tests/Feature/ContributionControllerTest.php`](diffhunk://#diff-48213d47f54f123d1e0b372c317940a5205c768674d0cecc92c5004c26a6d686L47-R47): Updated test cases to use the `notes` field instead of `description` for contributions and categories. [[1]](diffhunk://#diff-48213d47f54f123d1e0b372c317940a5205c768674d0cecc92c5004c26a6d686L47-R47) [[2]](diffhunk://#diff-48213d47f54f123d1e0b372c317940a5205c768674d0cecc92c5004c26a6d686L117-R117)
* [`tests/Unit/Actions/CalculateUserBalanceActionTest.php`](diffhunk://#diff-0f1e044137a5a6e62c0264a9e2dac8385aeddd7c3aa5e51eebccdf75c10bc155L31-R31): Changed `description` to `notes` for category setup.
* [`tests/Unit/Actions/CreateContributionActionTest.php`](diffhunk://#diff-e1dd5ea9d1e37d98d81f1e01c0202f1e41f8d6e4252ba9cbb6271c23caa5a645L31-R31): Updated both category setup and contribution creation tests to use the `notes` field. [[1]](diffhunk://#diff-e1dd5ea9d1e37d98d81f1e01c0202f1e41f8d6e4252ba9cbb6271c23caa5a645L31-R31) [[2]](diffhunk://#diff-e1dd5ea9d1e37d98d81f1e01c0202f1e41f8d6e4252ba9cbb6271c23caa5a645L46-R46)
* [`tests/Unit/Actions/GetContributionSummaryActionTest.php`](diffhunk://#diff-a522e91a38d8932d8abd812ab0dddd77a818393b5c46f62f8fd47c8b63b5e813L36-R44): Renamed `description` to `notes` for multiple category setups in the summary action tests.

### Removal of Redundant Test:
* [`tests/Feature/Feature/ContributionControllerTest.php`](diffhunk://#diff-309dc4c298227a6ce95ea7906c4b5640f8ac1f9f94fc3487906564e38e4dfaafL1-L7): Deleted an unused example test file to clean up the codebase.